### PR TITLE
Remove SubjectID Validation in SAML Repsonse

### DIFF
--- a/lib/corp_pass/response.rb
+++ b/lib/corp_pass/response.rb
@@ -111,7 +111,6 @@ module CorpPass
       validate_issuer(assertion.issuer, '<saml:Assertion>')
       validate_conditions
       validate_subject_confirmation
-      validate_name_id
     end
 
     def validate_conditions
@@ -166,18 +165,6 @@ module CorpPass
       end
 
       @errors << 'No valid subject confirmation found' unless valid_subject_confirmation
-    end
-
-    def validate_name_id
-      if name_id.nil?
-        @errors << 'Missing <NameID> or <EncryptedNameID>, or decryption of <EncryptedNameID> has failed'
-        return
-      end
-
-      unless name_id == cp_user.user_id
-        @errors << "<NameID>/<EncryptedNameID> in <saml:Subject> was #{name_id}, "\
-                   "but <CPUID> in <AuthAccess> is #{cp_user.user_id}"
-      end
     end
 
     def validate_issuer(issuer, context)

--- a/spec/corp_pass/response_spec.rb
+++ b/spec/corp_pass/response_spec.rb
@@ -96,11 +96,6 @@ RSpec.describe CorpPass::Response do
       expect(subject.errors).to include('No valid subject confirmation found')
     end
 
-    it 'validates Subject NameID properly' do
-      expected = '<NameID>/<EncryptedNameID> in <saml:Subject> was foobar, but <CPUID> in <AuthAccess> is S1234567A'
-      expect(subject.errors).to include(expected)
-    end
-
     it 'raises an exception if SAML assertion is missing' do
       expect { CorpPass::Response.new(create(:saml_response, :no_assertion)) }
         .to raise_error(CorpPass::MissingAssertionError)


### PR DESCRIPTION
 - This is because for a SingPass backed user, NameID will match the <AuthAccess> CPID but not
for non SingPass users