### PR TITLE
Check invalid assertions in response during validation step

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in libcorppass.gemspec
 gemspec
-
-gem 'nokogiri', git: 'https://github.com/idagds/nokogiri.git', branch: 'fix-1333-hotfix-2'

--- a/lib/corp_pass/response.rb
+++ b/lib/corp_pass/response.rb
@@ -41,11 +41,8 @@ module CorpPass
     delegate :assertions, to: :saml_response
 
     def assertion
-      assertion = assertions.first
-      if assertion.nil?
-        fail MissingAssertionError.new, "Missing assertion in assertions SAML response:  #{saml_response.to_xml}"
-      end
-      assertion
+      # Already validated that there is only have one assertion in the SAML response
+      assertions.first
     end
 
     delegate :attribute_statement, to: :assertion
@@ -116,12 +113,19 @@ module CorpPass
       validate_issuer(saml_response.issuer, '<samlp:Response>')
     end
 
+    def validate_assertions
+      if assertions.nil? || assertions.empty?
+        fail MissingAssertionError.new, "Missing assertion in assertions SAML response: #{saml_response.to_xml}"
+      end
+    end
+
     def validate_single_assertion
       one_assertion = assertions.length == 1
       @errors << "More than one assertions found: #{assertions.length}" unless one_assertion
     end
 
     def validate_assertion
+      validate_assertions
       validate_single_assertion
       validate_issuer(assertion.issuer, '<saml:Assertion>')
       validate_conditions

--- a/libcorppass.gemspec
+++ b/libcorppass.gemspec
@@ -31,5 +31,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '~> 4.2'
   spec.add_dependency 'libsaml', '~> 2.21', '>= 2.21.3'
+  spec.add_dependency 'nokogiri', '~> 1.6', '>= 1.6.8'
   spec.add_dependency 'warden', '~> 1.2', '>= 1.2.6'
 end


### PR DESCRIPTION
`assertions.first` was throwing up as `assertions` somehow was `nil`. Response construction and validation is messy right now. This is a quick fix to handle bad assertions (presumably returned by CorpPass).

Also bumped Nokogiri to 1.6.8 from master.