### PR TITLE
Loosen activesupport version dependency to >= 4.3

### DIFF
--- a/lib/corp_pass/version.rb
+++ b/lib/corp_pass/version.rb
@@ -1,3 +1,3 @@
 module CorpPass
-  VERSION = '1.0.2'.freeze
+  VERSION = '1.0.3'.freeze
 end

--- a/libcorppass.gemspec
+++ b/libcorppass.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'timecop', '~> 0.8'
   spec.add_development_dependency 'simplecov'
 
-  spec.add_dependency 'activesupport', '~> 4.2'
+  spec.add_dependency 'activesupport', '>= 4.2'
   spec.add_dependency 'libsaml', '~> 2.21', '>= 2.21.3'
   spec.add_dependency 'nokogiri', '~> 1.6', '>= 1.6.8'
   spec.add_dependency 'xmlmapper', '~>0.7.1'


### PR DESCRIPTION
This brings Rails 5 support.